### PR TITLE
Added make as dependency

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ proxy_repository: "https://github.com/z3APA3A/3proxy.git"
 
 proxy_source_path: "/usr/local/src/3proxy"
 proxy_binaries_path: "{{ proxy_source_path }}/src"
-proxy_dependencies: ["gcc", "git"]
+proxy_dependencies: ["gcc", "git", "make"]
 
 proxy_config_path: "/etc/3proxy"
 proxy_service_name: "3proxy"


### PR DESCRIPTION
The role will fail unless make is installed in the target system. While it's pretty common to have it already, it's not base package, so there can be machines that have it missing (just like mine did).